### PR TITLE
Simplified lisp-unit Interface

### DIFF
--- a/tests/group-by.lisp
+++ b/tests/group-by.lisp
@@ -194,4 +194,4 @@ the vector ALPHABET.
 
 (define-test run-creation-speed-tests (%run-creation-speed-tests))
 
-(run-tests )
+(run-tests :all)


### PR DESCRIPTION
The interface to lisp-unit has been simplified. This pull will update the call to run-tests to conform to the simplified interface.
